### PR TITLE
[ATR-123] fix: p 태그를 통한 text 추출

### DIFF
--- a/src/main/kotlin/attraction/run/html/HTMLHandler.kt
+++ b/src/main/kotlin/attraction/run/html/HTMLHandler.kt
@@ -15,7 +15,7 @@ object HTMLHandler {
     fun extractArticleFromHtmlContent(articles: List<Article>): List<Article> {
         return articles.map { article ->
             val elements = Jsoup.parse(article.contentHTML).body()
-            val textContent = elements.getElementsByTag("p").text()
+            val textContent = elements.text()
 
             article.apply {
                 this.thumbnailUrl = getThumbnailUrl(elements)
@@ -41,9 +41,16 @@ object HTMLHandler {
     }
 
     private fun getContentSummaryFromText(textContent: String) =
-            if (MAX_CONTENT_LENGTH > textContent.length) textContent
-            else textContent.substring(0 until MAX_CONTENT_LENGTH)
+            if (MAX_CONTENT_LENGTH > textContent.length) textContent else extractSummary(textContent)
+
+    private fun extractSummary(fullText: String): String {
+        val sentenceDelimiter = ". "
+        val startPoint = fullText.indexOf(sentenceDelimiter) + sentenceDelimiter.length
+        val summaryEndPoint = MAX_CONTENT_LENGTH + startPoint + sentenceDelimiter.length
+
+        return fullText.substring(startPoint until summaryEndPoint)
+    }
 
     // 사람은 1분에 약 150 ~ 200단어를 읽을 수 있다. (불용어 제외X)
-    private fun calculateReadingTimeFromText(text: String) = text.split(" ").size / WORDS_PER_MINUTE
+    private fun calculateReadingTimeFromText(fullText: String) = fullText.split(" ").size / WORDS_PER_MINUTE
 }


### PR DESCRIPTION
## ⚙️ PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- ATR - 123

<br/>

## 🔑 Key Changes

- HTML 본문에 <p> 태그 사이에 text가 존재하지 않고 <div> 태그 사이에 text가 존재하는 메일들이 있었습니다.

태그로 구분하는 것이 아닌 전체 HTML 본문에 텍스트를 가져와서 문장이 끝났을 때 찍는 .(온점)을 이용해서 subString으로 요약 내용을 추출했습니다.

<br/>

## 🤝🏻 To Reviewers

-

<br/>