### PR TITLE
[ATR-129] feature: 사용자들의 여러개 Article을 DB에 저장

### DIFF
--- a/src/main/kotlin/attraction/run/MailServiceApplication.kt
+++ b/src/main/kotlin/attraction/run/MailServiceApplication.kt
@@ -2,7 +2,9 @@ package attraction.run
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
+@EnableJpaAuditing
 @SpringBootApplication
 class MailServiceApplication
 

--- a/src/main/kotlin/attraction/run/article/Article.kt
+++ b/src/main/kotlin/attraction/run/article/Article.kt
@@ -1,10 +1,14 @@
 package attraction.run.article
 
 import jakarta.persistence.*
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlin.jvm.Transient
 
 @Entity
+@EntityListeners(AuditingEntityListener::class)
 class Article(
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,13 +34,10 @@ class Article(
     var readingTime: Int? = null
     @Column(nullable = false)
     lateinit var contentSummary: String
-    @Column(nullable = false)
-    lateinit var createdAt: LocalDate
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
 
     fun isSameUserEmail(userEmail: String) = this.userEmail == userEmail
-    override fun toString(): String {
-        return "Article(id=$id, title='$title', newsLetterEmail='$newsLetterEmail', userEmail='$userEmail', contentHTML='$contentHTML', receivedAt=$receivedAt)"
-    }
-
-
 }

--- a/src/main/kotlin/attraction/run/article/Article.kt
+++ b/src/main/kotlin/attraction/run/article/Article.kt
@@ -16,7 +16,9 @@ class Article(
         @Column(nullable = false)
         val title: String,
         @Column(nullable = false)
-        val newsLetterEmail: String,
+        val newsletterEmail: String,
+        @Column(nullable = false)
+        val newsletterNickname: String,
         @Column(nullable = false)
         val userEmail: String,
         @Transient

--- a/src/main/kotlin/attraction/run/batch/JpaItemListWriter.kt
+++ b/src/main/kotlin/attraction/run/batch/JpaItemListWriter.kt
@@ -1,0 +1,19 @@
+package attraction.run.batch
+
+import org.springframework.batch.item.Chunk
+import org.springframework.batch.item.database.JpaItemWriter
+
+class JpaItemListWriter<T>(
+        private val jpaItemWriter: JpaItemWriter<T>
+) : JpaItemWriter<List<T>>() {
+
+    override fun write(items: Chunk<out List<T>>) {
+        val totalEntity = Chunk<T>()
+
+        for (item in items) {
+            totalEntity.addAll(item)
+        }
+        jpaItemWriter.write(totalEntity)
+    }
+}
+

--- a/src/main/kotlin/attraction/run/gmail/GmailReader.kt
+++ b/src/main/kotlin/attraction/run/gmail/GmailReader.kt
@@ -112,9 +112,11 @@ object GmailReader {
         val data = messageDetails.payload.body.data
         val contentHTML = String(Base64.decodeBase64(data), StandardCharsets.UTF_8)
 
+        val newsletter = Newsletter(requireNotNull(associate["From"]) { "뉴스레터 정보가 존재하지 않습니다." })
         return Article(
                 title = requireNotNull(associate["Subject"]) { "제목이 존재하지 않습니다." },
-                newsLetterEmail = requireNotNull(associate["From"]?.extractEmailFromString()) { "뉴스레터 이메일 형식이 올바르지 않습니다." },
+                newsletterEmail = newsletter.email,
+                newsletterNickname = newsletter.nickname,
                 userEmail = requireNotNull(associate["To"]?.extractEmailFromString()) { "사용자 이메일 형식이 올바르지 않습니다." },
                 contentHTML = contentHTML,
                 receivedAt = requireNotNull(associate["Date"]?.toLocalDateFromMailSendDate()) { "전송한 날짜가 올바르지 않습니다." }

--- a/src/main/kotlin/attraction/run/gmail/Newsletter.kt
+++ b/src/main/kotlin/attraction/run/gmail/Newsletter.kt
@@ -1,0 +1,20 @@
+package attraction.run.gmail
+
+data class Newsletter(private val from: String) {
+    private companion object {
+        @JvmStatic
+        private val NICKNAME_EMAIL_REGEX = "\"([^\"]+)\"\\s*<([^>]+)>".toRegex()
+    }
+
+    val nickname: String
+    val email: String
+
+    init {
+        val match = NICKNAME_EMAIL_REGEX.find(from)
+
+        if (match != null) {
+            nickname = match.groupValues[1]
+            email = match.groupValues[2]
+        } else throw IllegalArgumentException("메일의 보낸사람 정보가 올바르지 않습니다.")
+    }
+}


### PR DESCRIPTION
## ⚙️ PR Type

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- ATR - 129

<br/>

## 🔑 Key Changes

- 사용자들에 Article들을 DB에 저장
  -  [JpaItemWriter에서 `List<Article>`를 저장하면서 발생한 문제](https://uhanuu.tistory.com/entry/Spring-Batch-JpaItemWriter%EC%97%90%EC%84%9C-ListEntity-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0)
- 메일의 보낸 사람 양식에서 Ex) `"미라클레터" <miraklelab@mk.co.kr>` 앞: 닉네임, 뒤: 이메일로 추출

<br/>

## 🤝🏻 To Reviewers

-

<br/>