### PR TITLE
[ATR-163] feature: 읽은 메일 처리하기

### DIFF
--- a/src/main/kotlin/attraction/run/gmail/GmailReader.kt
+++ b/src/main/kotlin/attraction/run/gmail/GmailReader.kt
@@ -17,8 +17,12 @@ import com.google.api.services.gmail.Gmail
 import com.google.api.services.gmail.model.Label
 import com.google.api.services.gmail.model.ListLabelsResponse
 import com.google.api.services.gmail.model.Message
+import com.google.api.services.gmail.model.ModifyMessageRequest
 import org.apache.commons.codec.binary.Base64
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.util.MimeTypeUtils
+import org.springframework.util.MimeTypeUtils.TEXT_HTML_VALUE
 import java.io.FileNotFoundException
 import java.io.InputStreamReader
 import java.nio.charset.StandardCharsets
@@ -31,6 +35,8 @@ import java.util.*
 class GmailReader(
         private val userMarkService: UserMarkService
 ) {
+    private val log = LoggerFactory.getLogger(this.javaClass)!!
+
     private companion object {
         private const val APPLICATION_NAME = "attraction"
         private val JSON_FACTORY: JsonFactory = GsonFactory.getDefaultInstance()
@@ -89,6 +95,8 @@ class GmailReader(
 
     private fun getMemberMessagesContent(gmailService: Gmail, user: User): List<Article> {
         val messages = getMessages(gmailService, user)
+        val messageIds = messages.map { it.id }
+        log.info("사용자: ${user.email} message ids: $messageIds")
 
         return messages.map { message ->
             val messageDetails = gmailService.users().messages().get("me", message.id).setFormat("full").execute()
@@ -100,19 +108,9 @@ class GmailReader(
 
     private fun getMessages(gmailService: Gmail, user: User): MutableList<Message> {
         return gmailService.users().messages().list("me")
-                .setLabelIds(getLabelIds(gmailService))
-                .setQ("is:unread")
+                .setQ("label:attraction is:unread")
                 .execute()
                 .messages ?: throw MailNotFoundException("${user.email} 사용자의 메일이 존재하지 않습니다.")
-    }
-
-    private fun getLabelIds(gmailService: Gmail): List<String> {
-        val labelsResponse: ListLabelsResponse = gmailService.users().labels().list("me").execute()
-
-        return labelsResponse.labels.stream()
-                .filter { it.name.equals(APPLICATION_NAME) }
-                .map(Label::getId)
-                .toList()
     }
 
     private fun createArticle(messageDetails: Message): Article {

--- a/src/main/kotlin/attraction/run/gmail/GmailReader.kt
+++ b/src/main/kotlin/attraction/run/gmail/GmailReader.kt
@@ -103,6 +103,8 @@ class GmailReader(
 
             createArticle(messageDetails).takeIf { it.isSameUserEmail(user.email) }
                     ?: throw IllegalArgumentException("사용자 이메일 정보가 올바르지 않습니다.")
+        }.apply {
+            removeUnReadLabel(messageIds, gmailService)
         }
     }
 
@@ -141,6 +143,13 @@ class GmailReader(
         val formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH)
         val zonedDateTime = ZonedDateTime.parse(this, formatter)
         return zonedDateTime.toLocalDate()
+    }
+
+    private fun removeUnReadLabel(messageIds: List<String>, gmailService: Gmail) {
+        val mods = ModifyMessageRequest().setRemoveLabelIds(listOf("UNREAD"))
+        messageIds.forEach {
+            gmailService.users().messages().modify("me", it, mods).execute()
+        }
     }
 }
 


### PR DESCRIPTION
## ⚙️ PR Type

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- ATR-163

<br/>

## 🔑 Key Changes

1️⃣ label 형식을 미리 지정해두고 지정한 라벨을 검색 조건 API를 통해서 조회합니다.
  - 기존에는 gmail api를 통해서 label을 조회한다음 필터링으로 메시지를 조회했습니다.
  - 미리 지정한 라벨을 통해서 조회하기  때문에 label을 조회할 필요가 없어 API 호출을 줄일 수 있습니다.

2️⃣ 사용자의 메일함에서 메일을 읽으면 해당하는 메일을 읽음 상태로 변경합니다.

3️⃣ 사용자 메일의 Content-type이 뉴스레터의 아티클인 경우 text/html로 들어오기 때문에 상관이 없지만 이 형식이 아닌 경우 로직에서 예외가 발생합니다. 
- 따라서 text/html 형식이 아닌 경우 skip하는 형태로 로직을 구성했습니다.


<br/>

## 🤝🏻 To Reviewers

-

<br/>