### PR TITLE
[ATR-264] feat: 썸네일 이미지 저장

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ out/
 
 # mailbox
 mailbox/
+thumbnail/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,10 +36,9 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
-    //DB
+    // DB
     implementation ("mysql:mysql-connector-java:8.0.33")
     implementation ("org.mariadb.jdbc:mariadb-java-client:2.7.2")
-
     // aws s3
     implementation ("io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1")
     // jsoup
@@ -48,6 +47,10 @@ dependencies {
     implementation ("com.google.api-client:google-api-client:2.0.0")
     implementation ("com.google.oauth-client:google-oauth-client-jetty:1.34.1")
     implementation ("com.google.apis:google-api-services-gmail:v1-rev20220404-2.0.0")
+    // webp + image resize
+    implementation("com.sksamuel.scrimage:scrimage-core:4.1.3")
+    implementation("com.sksamuel.scrimage:scrimage-webp:4.1.3")
+
 
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")

--- a/src/main/kotlin/attraction/run/article/Article.kt
+++ b/src/main/kotlin/attraction/run/article/Article.kt
@@ -8,7 +8,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.jvm.Transient
 
-@Table(name = "admin_article")
+@Table(name = "article")
 @Entity
 @EntityListeners(AuditingEntityListener::class)
 class Article(

--- a/src/main/kotlin/attraction/run/batch/GmailBatchConfig.kt
+++ b/src/main/kotlin/attraction/run/batch/GmailBatchConfig.kt
@@ -3,7 +3,7 @@ package attraction.run.batch
 import attraction.run.article.Article
 import attraction.run.gmail.GmailReader
 import attraction.run.gmail.MailNotFoundException
-import attraction.run.html.HTMLHandler
+import attraction.run.html.HTMLService
 import attraction.run.s3.S3Service
 import attraction.run.token.CannotAccessGmailException
 import attraction.run.token.GoogleRefreshToken
@@ -39,7 +39,8 @@ class GmailBatchConfig(
         @Qualifier("serverEntityManagerFactory")
         private val entityManagerFactory: EntityManagerFactory,
         private val s3Service: S3Service,
-        private val gmailReader: GmailReader
+        private val gmailReader: GmailReader,
+        private val htmlService: HTMLService
 ) {
     private val log = LoggerFactory.getLogger(this.javaClass)!!
 
@@ -75,8 +76,10 @@ class GmailBatchConfig(
                 .queryString("""
                     SELECT g FROM GoogleRefreshToken g 
                     WHERE g.shouldReissueToken = false
+                    AND g.email = :email
                     ORDER BY g.email
                 """.trimIndent())
+                .parameterValues(mapOf("email" to "attraction2312@gmail.com"))
                 .build()
     }
 
@@ -99,7 +102,7 @@ class GmailBatchConfig(
 
     @Bean
     fun mailContentProcessor(): ItemProcessor<List<Article>, List<Article>> {
-        return ItemProcessor<List<Article>, List<Article>>(HTMLHandler::extractArticleFromHtmlContent)
+        return ItemProcessor<List<Article>, List<Article>>(htmlService::extractArticleFromHtmlContent)
     }
 
     @Bean

--- a/src/main/kotlin/attraction/run/batch/GmailBatchConfig.kt
+++ b/src/main/kotlin/attraction/run/batch/GmailBatchConfig.kt
@@ -2,6 +2,7 @@ package attraction.run.batch
 
 import attraction.run.article.Article
 import attraction.run.gmail.GmailReader
+import attraction.run.gmail.MailNotFoundException
 import attraction.run.html.HTMLHandler
 import attraction.run.s3.S3Service
 import attraction.run.token.CannotAccessGmailException
@@ -34,7 +35,7 @@ const val CHUNK_SIZE = 100
 @Configuration
 @EnableBatchProcessing(dataSourceRef = "defaultDataSource", transactionManagerRef = "serverTransactionManager")
 @RequiredArgsConstructor
-class BatchConfig(
+class GmailBatchConfig(
         @Qualifier("serverEntityManagerFactory")
         private val entityManagerFactory: EntityManagerFactory,
         private val s3Service: S3Service,
@@ -59,6 +60,7 @@ class BatchConfig(
                 .faultTolerant()
                 .skipPolicy(RefreshTokenSkipPolicy())
                 .noRollback(CannotAccessGmailException::class.java)
+                .noRollback(MailNotFoundException::class.java)
                 .build()
     }
 

--- a/src/main/kotlin/attraction/run/config/MultiDataSourceConfig.kt
+++ b/src/main/kotlin/attraction/run/config/MultiDataSourceConfig.kt
@@ -62,16 +62,6 @@ class MultiDataSourceConfig : DefaultBatchConfiguration() {
         }
     }
 
-//    fun jpaProperties(): Properties {
-//
-//        return Properties().apply {
-//            setProperty("hibernate.dialect", env.getProperty("hibernate.dialect"));
-//        }
-//        properties.setProperty("hibernate.dialect", env.getProperty("hibernate.dialect"));
-//        properties.setProperty("hibernate.show_sql", env.getProperty("hibernate.show_sql"));
-//        properties.setProperty("hibernate.format_sql", env.getProperty("hibernate.format_sql"));
-//    }
-
     @Bean("serverTransactionManager")
     fun jpaTransactionManager(
             @Qualifier("serverEntityManagerFactory") entityManagerFactory: EntityManagerFactory): JpaTransactionManager {
@@ -80,7 +70,6 @@ class MultiDataSourceConfig : DefaultBatchConfiguration() {
             setJpaDialect(HibernateJpaDialect())
         }
     }
-
 
     override fun getTablePrefix(): String {
         return "ATTRACTION_"

--- a/src/main/kotlin/attraction/run/html/HTMLService.kt
+++ b/src/main/kotlin/attraction/run/html/HTMLService.kt
@@ -3,14 +3,15 @@ package attraction.run.html
 import attraction.run.article.Article
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
+import org.springframework.stereotype.Service
+import java.io.File
 
-object HTMLHandler {
-
-    private val EXTENSIONS = listOf(".jpg", ".jpeg", ".png")
-    private const val WORDS_PER_MINUTE = 200
-    private const val MAX_CONTENT_LENGTH = 200
-    private const val THUMBNAIL_IMG_INDEX = 1
-    private const val DEFAULT_IMG_INDEX = 0
+@Service
+class HTMLService(private val thumbnailUrlParser: ThumbnailUrlParser) {
+    private companion object {
+        private const val WORDS_PER_MINUTE = 200
+        private const val MAX_CONTENT_LENGTH = 200
+    }
 
     fun extractArticleFromHtmlContent(articles: List<Article>): List<Article> {
         return articles.map { article ->
@@ -27,17 +28,8 @@ object HTMLHandler {
 
     private fun getThumbnailUrl(body: Element): String {
         val imgTags = body.getElementsByTag("img")
-
-        val images = imgTags.map { it.attr("src") }
-                .filter { url ->
-                    EXTENSIONS.any { url.endsWith(it, ignoreCase = true) }
-                }.take(2)
-
-        return when (images.size) {
-            2 -> images[THUMBNAIL_IMG_INDEX]
-            1 -> images[DEFAULT_IMG_INDEX]
-            else -> ""
-        }
+        val thumbnailUrls = imgTags.map { it.attr("src") }
+        return thumbnailUrlParser.getThumbnailUrl(thumbnailUrls)
     }
 
     private fun getContentSummaryFromText(textContent: String) =

--- a/src/main/kotlin/attraction/run/html/HTMLService.kt
+++ b/src/main/kotlin/attraction/run/html/HTMLService.kt
@@ -4,7 +4,6 @@ import attraction.run.article.Article
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.springframework.stereotype.Service
-import java.io.File
 
 @Service
 class HTMLService(private val thumbnailUrlParser: ThumbnailUrlParser) {

--- a/src/main/kotlin/attraction/run/html/PixelFactory.kt
+++ b/src/main/kotlin/attraction/run/html/PixelFactory.kt
@@ -1,0 +1,74 @@
+package attraction.run.html
+
+import com.sksamuel.scrimage.pixels.Pixel
+import java.awt.image.BufferedImage
+import java.awt.image.DataBufferByte
+
+object PixelFactory {
+    fun getPixelArrayFromImage(image: BufferedImage): Array<Pixel> {
+        val width = image.width
+        val height = image.height
+        val hasAlphaChannel = image.alphaRaster != null
+        val data = (image.raster.dataBuffer as DataBufferByte).getData()
+
+        if (hasAlphaChannel) {
+            return getPixelsWithAlphaChannel(data, width, height)
+        }
+        return getPixels(data, width, height)
+    }
+
+    private fun getPixelsWithAlphaChannel(
+            data: ByteArray,
+            width: Int,
+            height: Int
+    ): Array<Pixel> {
+        val result = Array(height * width) { Pixel(0, 0, 0) }
+
+        val pixelLength = 4
+        var index = 0
+        for (pixel in data.indices step pixelLength) {
+            if (pixel + 3 >= data.size) break
+
+            var argb = 0
+            argb += (data[pixel].toInt() and 0xff shl 24) // alpha
+            argb += (data[pixel + 1].toInt() and 0xff) // blue
+            argb += (data[pixel + 2].toInt() and 0xff shl 8) // green
+            argb += (data[pixel + 3].toInt() and 0xff shl 16) // red
+
+            val row = index / width
+            val col = index % width
+
+            result[index] = Pixel(col, row, argb)
+            index++
+        }
+        return result
+    }
+
+    private fun getPixels(
+            data: ByteArray,
+            width: Int,
+            height: Int
+    ): Array<Pixel> {
+        val result = Array(height * width) { Pixel(0, 0, 0) }
+
+        val pixelLength = 3
+        var index = 0
+        for (pixel in data.indices step pixelLength) {
+            if (pixel + 2 >= data.size) break
+
+            var argb = 0
+            argb += -16777216 // 255 alpha
+            argb += (data[pixel].toInt() and 0xff) // blue
+            argb += (data[pixel + 1].toInt() and 0xff shl 8) // green
+            argb += (data[pixel + 2].toInt() and 0xff shl 16) // red
+
+            val row = index / width
+            val col = index % width
+
+            result[index] = Pixel(col, row, argb)
+            index++
+        }
+        return result
+    }
+
+}

--- a/src/main/kotlin/attraction/run/html/ThumbnailUrlParser.kt
+++ b/src/main/kotlin/attraction/run/html/ThumbnailUrlParser.kt
@@ -1,0 +1,72 @@
+package attraction.run.html
+
+import attraction.run.s3.S3Service
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.webp.WebpWriter
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.awt.image.BufferedImage
+import java.io.File
+import java.net.URI
+import java.util.*
+import javax.imageio.ImageIO
+
+@Service
+class ThumbnailUrlParser(
+        @Value("\${file.thumbnail-path}")
+        private val path: String,
+        private val s3Service: S3Service
+) {
+    private companion object {
+        private val EXTENSIONS = listOf(".jpg", ".jpeg", ".png")
+        private val IMAGE_ASPECT_RATIO_RANGE = 56.25..100.00
+        private const val TARGET_WIDTH = 720
+        private const val WEBP_SUFFIX = ".webp"
+    }
+
+    fun getThumbnailUrl(thumbnailUrls: List<String>): String {
+        initFilePath()
+        val bufferImages = getBufferImages(thumbnailUrls)
+        val images = bufferImages.filter(::imageRule).take(2)
+
+        return when (images.size) {
+            1 -> imageResizeAndConvertWebp(images[0])
+            2 -> imageResizeAndConvertWebp(images[1])
+            else -> ""
+        }
+    }
+
+    fun initFilePath() {
+        val file = File(path)
+        if (!file.exists()) {
+            file.mkdir()
+        }
+    }
+
+    private fun getBufferImages(thumbnailUrls: List<String>): List<BufferedImage> {
+        return thumbnailUrls.filter {
+            EXTENSIONS.any { it.endsWith(it, ignoreCase = true) }
+        }.map {
+            ImageIO.read(URI(it).toURL())
+        }
+    }
+
+    private fun imageRule(it: BufferedImage) =
+            it.height >= 300 && (it.height.toDouble() / it.width) * 100 in IMAGE_ASPECT_RATIO_RANGE
+
+    private fun imageResizeAndConvertWebp(image: BufferedImage): String {
+        val immutableImage = getImmutableImage(image)
+                .scaleToWidth(TARGET_WIDTH)
+                .output(WebpWriter.DEFAULT, File("$path/${UUID.randomUUID()}$WEBP_SUFFIX"))
+
+        return immutableImage.path
+    }
+
+    private fun getImmutableImage(image: BufferedImage): ImmutableImage =
+            ImmutableImage.create(
+                    image.width,
+                    image.height,
+                    PixelFactory.getPixelArrayFromImage(image),
+                    BufferedImage.TYPE_3BYTE_BGR
+            )
+}

--- a/src/main/kotlin/attraction/run/html/ThumbnailUrlParser.kt
+++ b/src/main/kotlin/attraction/run/html/ThumbnailUrlParser.kt
@@ -59,7 +59,9 @@ class ThumbnailUrlParser(
                 .scaleToWidth(TARGET_WIDTH)
                 .output(WebpWriter.DEFAULT, File("$path/${UUID.randomUUID()}$WEBP_SUFFIX"))
 
-        return immutableImage.path
+        s3Service.uploadThumbnailImg(immutableImage)
+        immutableImage.delete()
+        return immutableImage.name
     }
 
     private fun getImmutableImage(image: BufferedImage): ImmutableImage =

--- a/src/main/kotlin/attraction/run/s3/CustomID.kt
+++ b/src/main/kotlin/attraction/run/s3/CustomID.kt
@@ -1,7 +1,0 @@
-package attraction.run.s3
-
-object CustomID {
-
-    const val UUID_DEFAULT_REGEX = "-"
-    const val DEFAULT_START_NUMBER = 0
-}

--- a/src/main/kotlin/attraction/run/s3/S3Service.kt
+++ b/src/main/kotlin/attraction/run/s3/S3Service.kt
@@ -14,7 +14,7 @@ import java.util.*
 class S3Service(
         @Value("\${aws.s3.bucket}")
         private val bucket: String,
-        @Value("\${file.path}")
+        @Value("\${file.mail-path}")
         private val path: String,
         private val s3Operations: S3Operations
 ) {

--- a/src/main/kotlin/attraction/run/s3/S3Service.kt
+++ b/src/main/kotlin/attraction/run/s3/S3Service.kt
@@ -18,6 +18,11 @@ class S3Service(
         private val path: String,
         private val s3Operations: S3Operations
 ) {
+    private companion object {
+        private const val ARTICLE_FOLDER_NAME = "article"
+        private const val THUMBNAIL_FOLDER_NAME = "thumbnail"
+    }
+
     fun initFilePath() {
         val file = File(path)
         if (!file.exists()) {
@@ -31,7 +36,7 @@ class S3Service(
 
     private fun uploadArticle(article: Article): Article {
         val file = createFileFromHTMLContent(article.contentHTML)
-        val upload = uploadFileToS3(file)
+        val upload = uploadFileToS3(file, ARTICLE_FOLDER_NAME)
 
         if (!uploadUrlContainsFileName(upload, file)) {
             throw IllegalArgumentException("파일 이름이 올바르지 않습니다.")
@@ -52,10 +57,10 @@ class S3Service(
         }
     }
 
-    private fun uploadFileToS3(file: File) = s3Operations
+    private fun uploadFileToS3(file: File, folderName: String) = s3Operations
             .upload(
                     bucket,
-                    file.name,
+                    "$folderName/${file.name}",
                     file.inputStream(),
                     ObjectMetadata.builder()
                             .contentType(TEXT_HTML_VALUE)
@@ -63,4 +68,9 @@ class S3Service(
             )
 
     private fun uploadUrlContainsFileName(upload: S3Resource, file: File) = upload.url.toString().contains(file.name)
+
+    fun uploadThumbnailImg(img: File): String {
+        val upload = uploadFileToS3(img, THUMBNAIL_FOLDER_NAME)
+        return upload.filename
+    }
 }


### PR DESCRIPTION
## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- ATR-264

<br/>

## 🔑 Key Changes

다음 기능은 아래 와 같이 처리됩니다.
- 뉴스레터 아티클의 모든 이미지를 조회합니다.
- 조회한 이미지의 비율(aspect ratio)이 56.25% ~ 100% 사이인 이미지를 선택합니다.
- 이미지의 width를 720 기준으로 resize 합니다.
- resize한 이미지를 .webp 형태로 변환합니다.
- 변환한 이미지를 Amazon S3에 업로드 합니다.

## 이미지 최적화

### JPEG
![jpeg](https://github.com/Atractorrr/Attraction-Mail-Service-Batch/assets/110734817/2668b361-db84-470d-b405-0a10c3d22c01)
**84.36kB -> 39.26kB -> 23.02kB**  `72.71% 개선`

### PNG (손실 압축)
![png](https://github.com/Atractorrr/Attraction-Mail-Service-Batch/assets/110734817/373247ea-2985-4463-894b-efa5c73faea4)
**920.3 kB -> 366.94kB -> 22.4kB** `97.6% 개선`

<br/>

## 🤝🏻 To Reviewers

- @LC-02s 
- @kim0527 

<br/>