### PR TITLE
[ATR-280] refactor:  wrapper 객체를 통해서 image 라이브러리 의존성 제거

### DIFF
--- a/src/main/kotlin/attraction/run/gmail/GmailReader.kt
+++ b/src/main/kotlin/attraction/run/gmail/GmailReader.kt
@@ -94,10 +94,11 @@ class GmailReader(
     private fun getMemberMessagesContent(gmailService: Gmail, googleToken: GoogleRefreshToken): List<Article> {
         val messages = getMessages(gmailService, googleToken)
         val messageIds = messages.map { it.id }
-        log.info("사용자: ${googleToken.email} message ids: $messageIds")
+        log.info("사용자: ${googleToken.email} message ids: $messageIds messageSize=${messageIds.size}")
 
         return messages.mapNotNull { message ->
             val messageDetails = gmailService.users().messages().get("me", message.id).setFormat("full").execute()
+            log.info("mimetype=${messageDetails.payload.mimeType} message=${message.id}")
             if (!messageDetails.payload.mimeType.startsWith(TEXT_HTML_VALUE)) {
                 return@mapNotNull null
             }

--- a/src/main/kotlin/attraction/run/html/ThumbnailImg.kt
+++ b/src/main/kotlin/attraction/run/html/ThumbnailImg.kt
@@ -1,0 +1,31 @@
+package attraction.run.html
+
+import com.sksamuel.scrimage.ImmutableImage
+import java.awt.image.BufferedImage
+
+class ThumbnailImg(
+        private val image: BufferedImage
+) {
+    fun hasMinimumImageSize(size: Int): Boolean {
+        return image.width >= size && image.height >= size
+    }
+
+    fun hasAspectRatioRange(range: ClosedRange<Double>): Boolean {
+        return (image.height.toDouble() / image.width) * 100 in range
+    }
+
+    fun isImageSizeSmallerWidth(size: Int): Boolean {
+        return image.width < size
+    }
+
+    fun getImmutableImage(): ImmutableImage =
+            ImmutableImage.create(
+                    image.width,
+                    image.height,
+                    PixelFactory.getPixelArrayFromImage(image),
+                    BufferedImage.TYPE_3BYTE_BGR
+            )
+
+    fun getImmutableImageWithScaleToWidth(width: Int): ImmutableImage = getImmutableImage().scaleToWidth(width)
+
+}

--- a/src/main/kotlin/attraction/run/html/ThumbnailUrlParser.kt
+++ b/src/main/kotlin/attraction/run/html/ThumbnailUrlParser.kt
@@ -1,17 +1,16 @@
 package attraction.run.html
 
 import attraction.run.s3.S3Service
-import com.sksamuel.scrimage.ImmutableImage
 import com.sksamuel.scrimage.webp.WebpWriter
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.stereotype.Service
-import java.awt.image.BufferedImage
+import org.springframework.stereotype.Component
 import java.io.File
 import java.net.URI
 import java.util.*
 import javax.imageio.ImageIO
 
-@Service
+
+@Component
 class ThumbnailUrlParser(
         @Value("\${file.thumbnail-path}")
         private val path: String,
@@ -19,16 +18,14 @@ class ThumbnailUrlParser(
 ) {
     private companion object {
         private val EXTENSIONS = listOf(".jpg", ".jpeg", ".png")
-        private val IMAGE_ASPECT_RATIO_RANGE = 56.25..100.00
+        private val IMAGE_ASPECT_RATIO_RANGE = 30.00..100.00
         private const val TARGET_WIDTH = 720
         private const val WEBP_SUFFIX = ".webp"
     }
-
     fun getThumbnailUrl(thumbnailUrls: List<String>): String {
         initFilePath()
         val bufferImages = getBufferImages(thumbnailUrls)
         val images = bufferImages.filter(::imageRule).take(2)
-
         return when (images.size) {
             1 -> imageResizeAndConvertWebp(images[0])
             2 -> imageResizeAndConvertWebp(images[1])
@@ -43,32 +40,26 @@ class ThumbnailUrlParser(
         }
     }
 
-    private fun getBufferImages(thumbnailUrls: List<String>): List<BufferedImage> {
+    private fun getBufferImages(thumbnailUrls: List<String>): List<ThumbnailImg> {
         return thumbnailUrls.filter {
             EXTENSIONS.any { it.endsWith(it, ignoreCase = true) }
         }.map {
-            ImageIO.read(URI(it).toURL())
+            ThumbnailImg(ImageIO.read(URI(it).toURL()))
         }
     }
 
-    private fun imageRule(it: BufferedImage) =
-            it.height >= 300 && (it.height.toDouble() / it.width) * 100 in IMAGE_ASPECT_RATIO_RANGE
+    private fun imageRule(it: ThumbnailImg) =
+            it.hasMinimumImageSize(300) && it.hasAspectRatioRange(IMAGE_ASPECT_RATIO_RANGE)
 
-    private fun imageResizeAndConvertWebp(image: BufferedImage): String {
-        val immutableImage = getImmutableImage(image)
-                .scaleToWidth(TARGET_WIDTH)
-                .output(WebpWriter.DEFAULT, File("$path/${UUID.randomUUID()}$WEBP_SUFFIX"))
+    private fun imageResizeAndConvertWebp(thumbnailImg: ThumbnailImg): String {
+        val convertImage = if (thumbnailImg.isImageSizeSmallerWidth(TARGET_WIDTH)) {
+            thumbnailImg.getImmutableImage()
+        } else {
+            thumbnailImg.getImmutableImageWithScaleToWidth(TARGET_WIDTH)
+        }.output(WebpWriter.DEFAULT, File("$path/${UUID.randomUUID()}$WEBP_SUFFIX"))
 
-        s3Service.uploadThumbnailImg(immutableImage)
-        immutableImage.delete()
-        return immutableImage.name
+        s3Service.uploadThumbnailImg(convertImage)
+        convertImage.delete()
+        return convertImage.name
     }
-
-    private fun getImmutableImage(image: BufferedImage): ImmutableImage =
-            ImmutableImage.create(
-                    image.width,
-                    image.height,
-                    PixelFactory.getPixelArrayFromImage(image),
-                    BufferedImage.TYPE_3BYTE_BGR
-            )
 }


### PR DESCRIPTION
## ⚙️ PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- ATR-280

<br/>

## 🔑 Key Changes

- image 외부 라이브러리를 감싼 wrapper 객체를 만듬으로써 기능 로직에서 의존성을 분리할 수 있었습니다.

<br/>

## 🤝🏻 To Reviewers

- 

<br/>