### PR TITLE
[ATR-491] fix: mimeType 문제

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "mail-service"
+rootProject.name = "mail-service-batch"

--- a/src/main/kotlin/attraction/run/MailServiceBatchApplication.kt
+++ b/src/main/kotlin/attraction/run/MailServiceBatchApplication.kt
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @EnableJpaAuditing
 @SpringBootApplication
-class MailServiceApplication
+class MailServiceBatchApplication
 
 fun main(args: Array<String>) {
-    runApplication<MailServiceApplication>(*args)
+    runApplication<MailServiceBatchApplication>(*args)
 }

--- a/src/main/kotlin/attraction/run/article/Article.kt
+++ b/src/main/kotlin/attraction/run/article/Article.kt
@@ -12,22 +12,28 @@ import kotlin.jvm.Transient
 @Entity
 @EntityListeners(AuditingEntityListener::class)
 class Article(
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        val id: Long? = null,
-        @Column(nullable = false)
-        val title: String,
-        @Column(name = "newsletter_email", nullable = false)
-        val newsletterEmail: String,
-        @Column(name = "newsletter_nickname", nullable = false)
-        val newsletterNickname: String,
-        @Column(name = "user_email", nullable = false)
-        val userEmail: String,
-        @Transient
-        val contentHTML: String,
-        @Column(name = "received_at", nullable = false)
-        val receivedAt: LocalDate
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    @Column(nullable = false)
+    val title: String,
+    @Column(name = "newsletter_email", nullable = false)
+    val newsletterEmail: String,
+    @Column(name = "newsletter_nickname", nullable = false)
+    val newsletterNickname: String,
+    @Column(name = "user_email", nullable = false)
+    private var userEmail: String,
+    @Transient
+    val contentHTML: String,
+    @Column(name = "received_at", nullable = false)
+    val receivedAt: LocalDate
 ) {
+    init {
+        if (userEmail[10] != '.') {
+            this.userEmail = "attraction.${userEmail.substring(10)}"
+        }
+    }
+
     @Column(name = "is_deleted", nullable = false, columnDefinition = "TINYINT(1) default 0")
     val isDeleted = false
 

--- a/src/main/kotlin/attraction/run/batch/GmailBatchConfig.kt
+++ b/src/main/kotlin/attraction/run/batch/GmailBatchConfig.kt
@@ -76,10 +76,14 @@ class GmailBatchConfig(
                 .queryString("""
                     SELECT g FROM GoogleRefreshToken g 
                     WHERE g.shouldReissueToken = false
-                    AND g.email = :email
+                    AND g.email in :emails
                     ORDER BY g.email
                 """.trimIndent())
-                .parameterValues(mapOf("email" to "attraction2312@gmail.com"))
+                .parameterValues(mapOf("emails" to listOf("" +
+                        "attraction.subscribe@gmail.com",
+                        "attraction.subscribe2@gmail.com",
+                        "attraction.subscribe3@gmail.com"
+                    )))
                 .build()
     }
 

--- a/src/main/kotlin/attraction/run/gmail/GmailReader.kt
+++ b/src/main/kotlin/attraction/run/gmail/GmailReader.kt
@@ -30,7 +30,7 @@ import java.util.*
 
 @Component
 class GmailReader(
-        private val userMarkService: GoogleTokenMarkService
+    private val userMarkService: GoogleTokenMarkService
 ) {
     private val log = LoggerFactory.getLogger(this.javaClass)!!
 
@@ -38,7 +38,7 @@ class GmailReader(
         private const val APPLICATION_NAME = "attraction"
         private val JSON_FACTORY: JsonFactory = GsonFactory.getDefaultInstance()
         private const val CREDENTIALS_FILE_PATH = "/credentials.json"
-        private val EMAIL_REGEX = "<(.*?)>".toRegex()
+        private val EMAIL_REGEX = "(?<=<|^)([\\w._%+-]+@[\\w.-]+\\.[a-zA-Z]{2,})(?=>|$)".toRegex()
     }
 
     fun getMemberInboxArticle(googleToken: GoogleRefreshToken): List<Article> {
@@ -73,22 +73,22 @@ class GmailReader(
     }
 
     private fun getGoogleTokenResponse(
-            httpTransport: NetHttpTransport,
-            refreshToken: String,
-            details: GoogleClientSecrets.Details
+        httpTransport: NetHttpTransport,
+        refreshToken: String,
+        details: GoogleClientSecrets.Details
     ): GoogleTokenResponse = GoogleRefreshTokenRequest(
-            httpTransport,
-            JSON_FACTORY,
-            refreshToken,
-            details.clientId,
-            details.clientSecret
+        httpTransport,
+        JSON_FACTORY,
+        refreshToken,
+        details.clientId,
+        details.clientSecret
     ).execute()
 
 
     private fun getGmailService(httpTransport: NetHttpTransport, credential: Credential): Gmail {
         return Gmail.Builder(httpTransport, JSON_FACTORY, credential)
-                .setApplicationName(APPLICATION_NAME)
-                .build()
+            .setApplicationName(APPLICATION_NAME)
+            .build()
     }
 
     private fun getMemberMessagesContent(gmailService: Gmail, googleToken: GoogleRefreshToken): List<Article> {
@@ -99,12 +99,13 @@ class GmailReader(
         return messages.mapNotNull { message ->
             val messageDetails = gmailService.users().messages().get("me", message.id).setFormat("full").execute()
             log.info("mimetype=${messageDetails.payload.mimeType} message=${message.id}")
-            if (!messageDetails.payload.mimeType.startsWith(TEXT_HTML_VALUE)) {
+            val mimeType = messageDetails.payload.mimeType
+            if (!(mimeType.startsWith(TEXT_HTML_VALUE) || mimeType.startsWith("multipart/alternative"))) {
                 return@mapNotNull null
             }
 
             createArticle(messageDetails).takeIf { it.isSameUserEmail(googleToken.email) }
-                    ?: throw IllegalArgumentException("사용자 이메일 정보가 올바르지 않습니다.")
+                ?: throw IllegalArgumentException("사용자 이메일 정보가 올바르지 않습니다.")
         }.also {
             removeUnReadLabel(messageIds, gmailService)
             if (it.isEmpty()) throw throw MailNotFoundException("${googleToken.email} 사용자의 메일이 존재하지 않습니다.")
@@ -113,37 +114,55 @@ class GmailReader(
 
     private fun getMessages(gmailService: Gmail, googleToken: GoogleRefreshToken): MutableList<Message> {
         return gmailService.users().messages().list("me")
-                .setQ("label:attraction is:unread")
-                .execute()
-                .messages ?: throw MailNotFoundException("${googleToken.email} 사용자의 메일이 존재하지 않습니다.")
+            .setQ("label:attraction is:unread")
+            .execute()
+            .messages ?: throw MailNotFoundException("${googleToken.email} 사용자의 메일이 존재하지 않습니다.")
     }
 
     private fun createArticle(messageDetails: Message): Article {
         val associate = messageDetails.payload.headers
-                .associate { it.name to it.value }
-
-        val data = messageDetails.payload.body.data
-        val contentHTML = String(Base64.decodeBase64(data), StandardCharsets.UTF_8)
+            .associate { it.name to it.value }
+        val contentHTML = when (messageDetails.payload.mimeType) {
+            "text/html" -> {
+                val data = messageDetails.payload.body.data
+                String(Base64.decodeBase64(data), StandardCharsets.UTF_8)
+            }
+            "multipart/alternative" -> {
+                val builder = StringBuilder()
+                for (part in messageDetails.payload.parts) {
+                    val decodingData = String(Base64.decodeBase64(part.body.data), StandardCharsets.UTF_8)
+                    builder.append(decodingData)
+                }
+                builder.toString()
+            }
+            else -> throw IllegalArgumentException("content가 이상합니다.")
+        }
 
         val newsletter = Newsletter(requireNotNull(associate["From"]) { "뉴스레터 정보가 존재하지 않습니다." })
+        log.info("userEmail = ${associate["To"]}")
         return Article(
-                title = requireNotNull(associate["Subject"]) { "제목이 존재하지 않습니다." },
-                newsletterEmail = newsletter.email,
-                newsletterNickname = newsletter.nickname,
-                userEmail = requireNotNull(associate["To"]?.extractEmailFromString()) { "사용자 이메일 형식이 올바르지 않습니다." },
-                contentHTML = contentHTML,
-                receivedAt = requireNotNull(associate["Date"]?.toLocalDateFromMailSendDate()) { "전송한 날짜가 올바르지 않습니다." }
+            title = requireNotNull(associate["Subject"])
+            { "제목이 존재하지 않습니다." },
+            newsletterEmail = newsletter.email,
+            newsletterNickname = newsletter.nickname,
+            userEmail = requireNotNull(associate["To"]?.extractEmailFromString())
+            { "사용자 이메일 형식이 올바르지 않습니다." },
+            contentHTML = contentHTML,
+            receivedAt = requireNotNull(associate["Date"]?.toLocalDateFromMailSendDate())
+            { "전송한 날짜가 올바르지 않습니다." }
         )
     }
 
     private fun String.extractEmailFromString(): String {
         val matchResult = EMAIL_REGEX.find(this)
+        log.info("matchResult = ${matchResult?.groupValues?.get(1)}")
         return matchResult?.groupValues?.get(1) ?: throw IllegalArgumentException("메일의 이메일이 형식이 올바르지 않습니다.")
     }
 
     private fun String.toLocalDateFromMailSendDate(): LocalDate {
+        val cleanedString = this.substringBefore(" (UTC)")
         val formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH)
-        val zonedDateTime = ZonedDateTime.parse(this, formatter)
+        val zonedDateTime = ZonedDateTime.parse(cleanedString, formatter)
         return zonedDateTime.toLocalDate()
     }
 

--- a/src/main/kotlin/attraction/run/gmail/GmailReader.kt
+++ b/src/main/kotlin/attraction/run/gmail/GmailReader.kt
@@ -131,10 +131,10 @@ class GmailReader(
             "multipart/alternative" -> {
                 val builder = StringBuilder()
                 for (part in messageDetails.payload.parts) {
-                    val decodingData = String(Base64.decodeBase64(part.body.data), StandardCharsets.UTF_8)
+                    val decodingData = String(Base64.decodeBase64(part.body.data), StandardCharsets.UTF_8).trim()
 
                     log.info("제목 = ${associate["Subject"]} decodingData = $decodingData")
-                    if (decodingData.endsWith("</html>")) {
+                    if (decodingData.endsWith("</html>", ignoreCase = true)) {
                         builder.append(decodingData)
                     }
                 }

--- a/src/main/kotlin/attraction/run/gmail/GmailReader.kt
+++ b/src/main/kotlin/attraction/run/gmail/GmailReader.kt
@@ -122,6 +122,7 @@ class GmailReader(
     private fun createArticle(messageDetails: Message): Article {
         val associate = messageDetails.payload.headers
             .associate { it.name to it.value }
+
         val contentHTML = when (messageDetails.payload.mimeType) {
             "text/html" -> {
                 val data = messageDetails.payload.body.data
@@ -131,7 +132,11 @@ class GmailReader(
                 val builder = StringBuilder()
                 for (part in messageDetails.payload.parts) {
                     val decodingData = String(Base64.decodeBase64(part.body.data), StandardCharsets.UTF_8)
-                    builder.append(decodingData)
+
+                    log.info("제목 = ${associate["Subject"]} decodingData = $decodingData")
+                    if (decodingData.endsWith("</html>")) {
+                        builder.append(decodingData)
+                    }
                 }
                 builder.toString()
             }

--- a/src/main/kotlin/attraction/run/gmail/Newsletter.kt
+++ b/src/main/kotlin/attraction/run/gmail/Newsletter.kt
@@ -10,14 +10,16 @@ data class Newsletter(private val from: String) {
     val email: String
 
     init {
-        val split = from.trim().split(" ")
+        val lastIndexOf = from.lastIndexOf("<")
+        val fromNickname = from.substring(0, lastIndexOf - 1).trim()
+        val fromEmail = from.substring(lastIndexOf + 1, from.length - 1)
 
-        val fromNickname = split[0]
-        if (fromNickname.startsWith("\"") && fromNickname.endsWith("\"")) {
-            nickname = fromNickname.substring(1, fromNickname.length - 1)
-        } else nickname = fromNickname
-
-        val fromEmail = split[1]
-        email = fromEmail.substring(1, fromEmail.length - 1)
+        nickname = if (fromNickname[0] == '"') {
+            fromNickname.substring(1, fromNickname.length - 1)
+        } else {
+            fromNickname
+        }
+        email = fromEmail.trim()
+        log.info("nickname=$nickname email=$email")
     }
 }

--- a/src/main/kotlin/attraction/run/html/HTMLService.kt
+++ b/src/main/kotlin/attraction/run/html/HTMLService.kt
@@ -19,8 +19,11 @@ class HTMLService(private val thumbnailUrlParser: ThumbnailUrlParser) {
 
             article.apply {
                 this.thumbnailUrl = getThumbnailUrl(elements)
+                println("thumbnailUrl = $thumbnailUrl")
                 this.contentSummary = getContentSummaryFromText(textContent)
+                println("contentSummary = $contentSummary")
                 this.readingTime = calculateReadingTimeFromText(textContent)
+                println("readingTime = $readingTime")
             }
         }
     }
@@ -39,7 +42,10 @@ class HTMLService(private val thumbnailUrlParser: ThumbnailUrlParser) {
         val startPoint = fullText.indexOf(sentenceDelimiter) + sentenceDelimiter.length
         val summaryEndPoint = MAX_CONTENT_LENGTH + startPoint + sentenceDelimiter.length - sentenceDelimiter.length
 
-        return fullText.substring(startPoint until summaryEndPoint).trim()
+        println("summaryEndPoint = $summaryEndPoint")
+        return fullText.substring(startPoint until
+                if (fullText.length < summaryEndPoint) fullText.length else summaryEndPoint
+        ).trim()
     }
 
     // 사람은 1분에 약 150 ~ 200단어를 읽을 수 있다. (불용어 제외X)

--- a/src/main/kotlin/attraction/run/html/ThumbnailImg.kt
+++ b/src/main/kotlin/attraction/run/html/ThumbnailImg.kt
@@ -7,10 +7,20 @@ class ThumbnailImg(
         private val image: BufferedImage
 ) {
     fun hasMinimumImageSize(size: Int): Boolean {
+        println("""
+            width = ${image.width} 
+            height = ${image.height}
+            image.width >= size = ${image.width >= size}
+            image.height >= size = ${image.height >= size}
+        """.trimIndent())
         return image.width >= size && image.height >= size
     }
 
     fun hasAspectRatioRange(range: ClosedRange<Double>): Boolean {
+        println("""
+            퍼센트 = ${(image.height.toDouble() / image.width) * 100}
+            result = ${(image.height.toDouble() / image.width) * 100 in range}
+        """.trimIndent())
         return (image.height.toDouble() / image.width) * 100 in range
     }
 

--- a/src/main/kotlin/attraction/run/html/ThumbnailUrlParser.kt
+++ b/src/main/kotlin/attraction/run/html/ThumbnailUrlParser.kt
@@ -19,7 +19,7 @@ class ThumbnailUrlParser(
 ) {
     private companion object {
         private val EXTENSIONS = listOf(".jpg", ".jpeg", ".png")
-        private val IMAGE_ASPECT_RATIO_RANGE = 30.00..100.00
+        private val IMAGE_ASPECT_RATIO_RANGE = 30.00..120.00
         private const val TARGET_WIDTH = 720
         private const val WEBP_SUFFIX = ".webp"
     }
@@ -30,6 +30,7 @@ class ThumbnailUrlParser(
         initFilePath()
         val bufferImages = getBufferImages(thumbnailUrls)
         val images = bufferImages.filter(::imageRule).take(2)
+        log.info("size = ${images.size}")
         return when (images.size) {
             1 -> imageResizeAndConvertWebp(images[0])
             2 -> imageResizeAndConvertWebp(images[1])
@@ -46,7 +47,10 @@ class ThumbnailUrlParser(
 
     private fun getBufferImages(thumbnailUrls: List<String>): List<ThumbnailImg> {
         return thumbnailUrls.filter { url ->
-            EXTENSIONS.any { url.endsWith(it, ignoreCase = true) }
+            EXTENSIONS.any {
+                val lastIndexOf = url.lastIndexOf(it, ignoreCase = true)
+                lastIndexOf != -1
+            }
         }.map {
             log.info("image url = $it")
             ThumbnailImg(ImageIO.read(URI(it).toURL()))

--- a/src/main/kotlin/attraction/run/html/ThumbnailUrlParser.kt
+++ b/src/main/kotlin/attraction/run/html/ThumbnailUrlParser.kt
@@ -2,6 +2,7 @@ package attraction.run.html
 
 import attraction.run.s3.S3Service
 import com.sksamuel.scrimage.webp.WebpWriter
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.io.File
@@ -22,6 +23,9 @@ class ThumbnailUrlParser(
         private const val TARGET_WIDTH = 720
         private const val WEBP_SUFFIX = ".webp"
     }
+
+    private val log = LoggerFactory.getLogger(this.javaClass)!!
+
     fun getThumbnailUrl(thumbnailUrls: List<String>): String {
         initFilePath()
         val bufferImages = getBufferImages(thumbnailUrls)
@@ -41,9 +45,10 @@ class ThumbnailUrlParser(
     }
 
     private fun getBufferImages(thumbnailUrls: List<String>): List<ThumbnailImg> {
-        return thumbnailUrls.filter {
-            EXTENSIONS.any { it.endsWith(it, ignoreCase = true) }
+        return thumbnailUrls.filter { url ->
+            EXTENSIONS.any { url.endsWith(it, ignoreCase = true) }
         }.map {
+            log.info("image url = $it")
             ThumbnailImg(ImageIO.read(URI(it).toURL()))
         }
     }

--- a/src/test/kotlin/attraction/run/MailServiceBatchApplicationTests.kt
+++ b/src/test/kotlin/attraction/run/MailServiceBatchApplicationTests.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
-class MailServiceApplicationTests {
+class MailServiceBatchApplicationTests {
 
     @Test
     fun contextLoads() {


### PR DESCRIPTION
## ⚙️ PR Type

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- ATR-491

<br/>

## 🔑 Key Changes

- [X]  multipart/alternative도 지원하도록 수정했습니다.
- 기존에는 메일 mimeType - text/html만 가능했습니다.

- [X] 사용자가 구독했던 뉴스레터에서 attraction.sub을 attractionsub으로 전송하면서 예외가 발생했던 문제 해결했습니다.

- [X] 메일 전송 날짜를 (UTC)포맷까지 전송해주는 메일이 있어 예외가 발생했습니다.
- UTC 포맷 추가 전송시 제거할 수 있도록 수정했습니다.

뉴스레터 전송인 포맷이 다음과 같습니다.
"뉴스레터 닉네임 <뉴스레터 이메일>"

- [X] 뉴스레터 닉네임 파싱하는데 문제가 있어서 수정했습니다.

<br/>

## 🤝🏻 To Reviewers

-

<br/>